### PR TITLE
Feature/ond211 1760 training phrases listing and

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,11 +1,11 @@
 # Release History
 *****************
 
-## Release ONDEWO NLU APIS 1.1.1
+## Release ONDEWO NLU APIS 1.2.0
 
 ### New Features
- * [OND211-1732] Implement endpoints directly create/update/get/delete training phrases.
-
+ * [OND211-1760] Implement endpoint to directly list training phrases.
+ * [OND211-1732] Implement endpoints to directly create/update/get/delete training phrases.
 
 ## Release ONDEWO NLU APIS 1.1.0
 

--- a/ondewo/nlu/intent.proto
+++ b/ondewo/nlu/intent.proto
@@ -140,7 +140,7 @@ service Intents {
     rpc DeleteTrainingPhrase(DeleteTrainingPhraseRequest) returns (google.protobuf.Empty);
 
     // List training phrases (of a specific intent).
-    rpc ListTrainingPhrase(ListTrainingPhraseRequest) returns (ListTrainingPhraseResponse);
+    rpc ListTrainingPhrases(ListTrainingPhrasesRequest) returns (ListTrainingPhrasesResponse);
 
 }
 
@@ -974,7 +974,7 @@ message DeleteTrainingPhraseRequest {
 }
 
 // The request message for TrainingPhraseRequest
-message ListTrainingPhraseRequest {
+message ListTrainingPhrasesRequest {
     // Required. The agent to list all intents from.
     // Format: `projects/<Project ID>/agent/intents/<Intent ID>`.
     string intent_name = 1;
@@ -989,7 +989,7 @@ message ListTrainingPhraseRequest {
 
 
 // The response message for ListTrainingPhrase
-message ListTrainingPhraseResponse {
+message ListTrainingPhrasesResponse {
     // The list of training phrases. There will be a maximum number of items
     // returned based on the page_token field in the request.
     repeated Intent.TrainingPhrase training_phrases = 1;

--- a/ondewo/nlu/intent.proto
+++ b/ondewo/nlu/intent.proto
@@ -139,6 +139,9 @@ service Intents {
     // Delete a specific training phrase (of a specific intent).
     rpc DeleteTrainingPhrase(DeleteTrainingPhraseRequest) returns (google.protobuf.Empty);
 
+    // List training phrases (of a specific intent).
+    rpc ListTrainingPhrase(ListTrainingPhraseRequest) returns (ListTrainingPhraseResponse);
+
 }
 
 // Represents an intent.
@@ -974,4 +977,30 @@ message DeleteTrainingPhraseRequest {
     // Required. The name of the training phrase.
     // Format: `projects/<Project ID>/agent/intents/<Intent ID>/trainingPhrases/<Training Phrase ID>`
     string name = 1;
+}
+
+// The request message for TrainingPhraseRequest
+message ListTrainingPhraseRequest {
+    // Required. The agent to list all intents from.
+    // Format: `projects/<Project ID>/agent/intents/<Intent ID>`.
+    string intent_name = 1;
+
+    // Optional. The language to list training phrases, parameters and rich
+    // messages for. If not specified, the agent's default language is used.
+    string language_code = 2;
+
+    // Optional. The next_page_token value returned from a previous list request.
+    string page_token = 3
+}
+
+
+// The response message for ListTrainingPhrase
+message ListTrainingPhraseResponse {
+    // The list of training phrases. There will be a maximum number of items
+    // returned based on the page_token field in the request.
+    repeated Intent.TrainingPhrase training_phrases = 1;
+
+    // Token to retrieve the next page of results, or empty if there are no
+    // more results in the list.
+    string next_page_token = 2;
 }

--- a/ondewo/nlu/intent.proto
+++ b/ondewo/nlu/intent.proto
@@ -730,6 +730,8 @@ message Intent {
     // name of this intent as a root_name.
     repeated FollowupIntentInfo followup_intent_info = 18;
 
+    // Format: `current_index-<CURRENT_INDEX>--page_size-<PAGE_SIZE>`
+    // where <CURRENT_INDEX> and <PAGE_SIZE> are of type int
     string next_page_token = 30;
 
     // Optional. Domain to which the intent belongs
@@ -765,6 +767,8 @@ message ListIntentsRequest {
     IntentView intent_view = 3;
 
     // Optional. The next_page_token value returned from a previous list request.
+    // Format: `current_index-<CURRENT_INDEX>--page_size-<PAGE_SIZE>`
+    // where <CURRENT_INDEX> and <PAGE_SIZE> are of type int
     string page_token = 5;
 
     // Optional. Applies a filter to the list. Default, no filter.
@@ -782,6 +786,8 @@ message ListIntentsResponse {
 
     // Token to retrieve the next page of results, or empty if there are no
     // more results in the list.
+    // Format: `current_index-<CURRENT_INDEX>--page_size-<PAGE_SIZE>`
+    // where <CURRENT_INDEX> and <PAGE_SIZE> are of type int
     string next_page_token = 2;
 }
 
@@ -801,6 +807,9 @@ message GetIntentRequest {
     // Optional. The resource view to apply to the returned intent.
     IntentView intent_view = 3;
 
+    // Optional. The next_page_token value returned from a previous list request.
+    // Format: `current_index-<CURRENT_INDEX>--page_size-<PAGE_SIZE>`
+    // where <CURRENT_INDEX> and <PAGE_SIZE> are of type int
     string page_token = 10;
 }
 
@@ -1010,6 +1019,8 @@ message ListTrainingPhrasesRequest {
     string language_code = 2;
 
     // Optional. The next_page_token value returned from a previous list request.
+    // Format: `current_index-<CURRENT_INDEX>--page_size-<PAGE_SIZE>--sub_field-<SUB_FIELD>`
+    // where <CURRENT_INDEX> and <PAGE_SIZE> are of type int, <SUB_FIELD> is of type str (example: `training_phrases`)
     string page_token = 3;
 }
 
@@ -1022,5 +1033,7 @@ message ListTrainingPhrasesResponse {
 
     // Token to retrieve the next page of results, or empty if there are no
     // more results in the list.
+    // Format: `current_index-<CURRENT_INDEX>--page_size-<PAGE_SIZE>--sub_field-<SUB_FIELD>`
+    // where <CURRENT_INDEX> and <PAGE_SIZE> are of type int, <SUB_FIELD> is of type str (example: `training_phrases`)
     string next_page_token = 2;
 }

--- a/ondewo/nlu/intent.proto
+++ b/ondewo/nlu/intent.proto
@@ -990,7 +990,7 @@ message ListTrainingPhraseRequest {
     string language_code = 2;
 
     // Optional. The next_page_token value returned from a previous list request.
-    string page_token = 3
+    string page_token = 3;
 }
 
 


### PR DESCRIPTION
This PR adds ListTrainingPhrases rpc endpoint to intent.proto, with the corresponding messages ListTrainingPhrasesRequest and ListTrainingPhrasesResponse.

These endpoints enable the retrieval of training phrases from an intent without returning the whole intent object.