### PR TITLE
Ond233 181 add audio bytes to streaming detect intent response

### DIFF
--- a/ondewo/nlu/session.proto
+++ b/ondewo/nlu/session.proto
@@ -361,8 +361,7 @@ message StreamingDetectIntentRequest {
     bool single_utterance = 4;
 
     // Optional. The input audio content to be recognized. Must be sent if
-    // `query_input` was set to a streaming input audio config. The complete audio
-    // over all streaming messages must not exceed 1 minute.
+    // `query_input` was set to a streaming input audio config.
     bytes input_audio = 6;
 }
 
@@ -391,6 +390,9 @@ message StreamingDetectIntentResponse {
 
     // Specifies the status of the webhook request.
     google.rpc.Status webhook_status = 4;
+
+    // Synthetized audio bytes
+    bytes audio = 5;
 }
 
 // Contains a speech recognition result corresponding to a portion of the audio


### PR DESCRIPTION
Audio bytes field added to `StreamingDetectIntentResponse` as a preparation for end to end system with audio input and audio output, that might be used by CSI in the future.

Right now it is not used and a [CSI conversation servicer](https://github.com/ondewo/ondewo-csi-api/blob/master/ondewo/csi/conversation.proto) with a new endpoint is used.