### PR TITLE
Feature/ond211 2380 allow changing the models that rag chat and rag retrieval uses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ export
 
 # MUST BE THE SAME AS API in Mayor and Minor Version Number
 # example: API 2.9.0 --> Client 2.9.X
-ONDEWO_NLU_API_VERSION=6.8.0
+ONDEWO_NLU_API_VERSION=6.9.0
 
 # You need to setup an access token at https://github.com/settings/tokens - permissions are important
 GITHUB_GH_TOKEN?=ENTER_YOUR_TOKEN_HERE

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,14 @@
 
 *****************
 
+## Release ONDEWO NLU API 6.9.0
+
+### Improvements
+
+* [[OND211-2380]](https://ondewo.atlassian.net/browse/OND211-2380) Added additional fields to `RagCreateDataset`, `RagUpdateDataset`, and `RagRetrieval` to allow the user to configure the embedding/rerank models
+
+*****************
+
 ## Release ONDEWO NLU API 6.8.0
 
 ### Improvements

--- a/ondewo/nlu/rag.proto
+++ b/ondewo/nlu/rag.proto
@@ -1185,9 +1185,6 @@ message RagChunk {
     // Similarity score between <code>0.0</code> and <code>1.0</code> (only populated in retrieval responses).
     optional float similarity = 11;
 
-    // Parent document file name.
-    string document_name = 12;
-
 }
 
 // Aggregated document retrieval results containing how many chunks of the given document where retrieved

--- a/ondewo/nlu/rag.proto
+++ b/ondewo/nlu/rag.proto
@@ -517,6 +517,9 @@ message RagUpdateDatasetRequest {
     // Optional. Minimum 0. Maximum 100. PageRank value.
     optional int32 pagerank = 9;
 
+    // Optional. CCAI service to use for embedding the documents in the dataset.
+    string embedding_ccai_service_name = 10;
+
 }
 
 // Request message for deleting one or more of a RAGFlow resource.

--- a/ondewo/nlu/rag.proto
+++ b/ondewo/nlu/rag.proto
@@ -254,6 +254,9 @@ message RagCreateDatasetRequest {
     // Optional. Configuration settings for the dataset parser. The used fields vary depending on the selected <code>chunk_method</code>.
     RagParserConfig parser_config = 7;
 
+    // Optional if <code>dataset_default_embedding_ccai_service_name</code> is set in the ONDEWO config, otherwise mandatory. CCAI service to use for embedding the documents in the dataset.
+    string embedding_ccai_service_name = 8;
+
 }
 
 // Chunking method for documents. See <a href="https://ragflow.io/docs/dev/configure_knowledge_base#select-chunking-method">https://ragflow.io/docs/dev/configure_knowledge_base#select-chunking-method</a> for details.
@@ -1078,6 +1081,9 @@ message RagRetrievalRequest {
 
     // Optional. Extract additional keywords from the query to improve retrieval.
     optional bool keyword = 14;
+
+    // Optional. Rerank model used to refine the initial retrieval scores. If not provided, the default model is used (if one is set). If empty, the results are not reranked.
+    optional string rerank_ccai_service_name = 15;
 
 }
 

--- a/ondewo/nlu/rag.proto
+++ b/ondewo/nlu/rag.proto
@@ -1185,6 +1185,9 @@ message RagChunk {
     // Similarity score between <code>0.0</code> and <code>1.0</code> (only populated in retrieval responses).
     optional float similarity = 11;
 
+    // Parent document file name.
+    string document_name = 12;
+
 }
 
 // Aggregated document retrieval results containing how many chunks of the given document where retrieved

--- a/ondewo/nlu/rag.proto
+++ b/ondewo/nlu/rag.proto
@@ -255,7 +255,7 @@ message RagCreateDatasetRequest {
     RagParserConfig parser_config = 7;
 
     // Optional if <code>dataset_default_embedding_ccai_service_name</code> is set in the ONDEWO config, otherwise mandatory. CCAI service to use for embedding the documents in the dataset.
-    string embedding_ccai_service_name = 8;
+    string embedding_model_ccai_service_name = 8;
 
 }
 
@@ -524,7 +524,7 @@ message RagUpdateDatasetRequest {
     optional google.protobuf.FieldMask field_mask = 11;
 
     // Optional. CCAI service to use for embedding the documents in the dataset.
-    string embedding_ccai_service_name = 12;
+    string embedding_model_ccai_service_name = 12;
 
 }
 
@@ -1126,7 +1126,7 @@ message RagRetrievalRequest {
     optional google.protobuf.FieldMask field_mask = 15;
 
     // Optional. Rerank model used to refine the initial retrieval scores. If not provided, the default model is used (if one is set). If empty, the results are not reranked.
-    optional string rerank_ccai_service_name = 16;
+    optional string rerank_model_ccai_service_name = 16;
 
 }
 


### PR DESCRIPTION
Added additional fields to `RagCreateDataset`, `RagUpdateDataset`, and `RagRetrieval` to allow the user to configure the embedding/rerank models